### PR TITLE
Change how storage works, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,9 @@ var Dat = require('dat-js')
 var dat = new Dat()
 var repo = dat.create()
 
-// The URL will only be available after the `ready` event
-repo.ready(() => {
-  console.log('dat url is:', repo.url)
-})
+console.log('dat url is:', repo.url)
 
-// You can start reading/writing before it's `ready`
+// You can start reading/writing right away
 var writer = repo.archive.createWriteStream('hello.txt')
 
 writer.write('world')
@@ -110,12 +107,12 @@ repo.archive.readFile('/example.txt', 'utf-8', (err, data) => {
 Creates a new dat object. The options passed here will be default for any dats created using the `add` method.
 
  * `options`: any options you can pass to [mafintosh/hyperdrive](https://github.com/mafintosh/hyperdrive). These options will become default for all dats. In addition it has the following:
-  * `signalhub`: An optional string or array of strings for [signalhubws](https://github.com/soyuka/signalhubws) servers to use for WebRTC. Note that this isn't compatible with older `signalhub` servers. These servers are used to discover and connect to WebRTC peers.
-  * `gateway`: An optional string or array of strings for [dat-gateway](https://github.com/garbados/dat-gateway/) instances for websocket replication. This is used to proxy data from the rest of the dat network when there are no WebRTC peers available with your data.
+  * `signalhub`: An optional string or array of strings for [signalhubws](https://github.com/soyuka/signalhubws) servers to use for WebRTC. Note that this isn't compatible with older `signalhub` servers. These servers are used to discover and connect to WebRTC peers. Note that each signalhub constitutes a different WebRTC swarm. The default is `https://signalhubws.mauve.moe/`
+  * `gateway`: An optional string or array of strings for [dat-gateway](https://github.com/garbados/dat-gateway/) instances for websocket replication. This is used to proxy data from the rest of the dat network when there are no WebRTC peers available with your data. There is no gateway set by default, but you can use `https://gateway.mauve.moe/` if you want it.
 
 ### `dat.get(url, [options])`
 
-Adds a new dat with the given url. Joins the appropriate swarm for that url and begins to upload and download data. If the dat was already added, it will return the existing instance.
+Adds a new dat with the given url. Joins the appropriate swarm for that url and begins to upload and download data. If the dat was already added, it will return the existing instance. One gotcha is that dat-js doesn't support DNS resolution yet. As such you'll need to use the actual archive key for loading websites.
 
  * `url`: Either a `dat://` url or just the public key in string form.
  * `options`: These options will override any options given in the Dat constructor.
@@ -148,17 +145,17 @@ The `dat://` url of the repo. Note that for newly created repos, you must wait f
 
 Invokes the `cb` once the repo is fully initialized. You can do reads and writes from the archive before then, but this is important if you're creating a new archive. If the repo is already `ready`, it will invoke `cb` on the next tick.
 
-#### `repo.destroy()`
+#### `repo.close()`
 
-Destroys the swarm and underlying database.
-
-#### `repo.swarm`
-
-Get to the original `webrtc-swarm` instance, where the swarm can be managed.
+Closes the swarm and underlying database.
 
 #### `repo.archive`
 
-Get to the original `hyperdrive` archive instance, where files can be managed using that api.
+Get the [hyperdrive](https://github.com/mafintosh/hyperdrive/#api) archive instance, where files can be managed using that api.
+
+#### `repo.swarm`
+
+Get the [webrtc-swarm](https://github.com/mafintosh/webrtc-swarm/#api) instance, where the swarm can be managed.
 
 ### Events
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "buffer-alloc-unsafe": "^1.0.0",
     "dat-encoding": "^5.0.1",
+    "hypercore-crypto": "^1.0.0",
     "hyperdrive": "^9.4.7",
     "pump": "^1.0.3",
     "random-access-memory": "^2.4.0",


### PR DESCRIPTION
Fixes #16 

With this change, we can reuse a single random-access-* instance between all the repos (for example random-accessidb). Each repo will prefix files it tries to access with it's public key.

A cool side-effect is that we no longer need to wait for the `ready()` event in order to get the URL for a new dat since the keypairs are created before hyperdrive is initialized.