### PR TITLE
Advertise DatJS on the Dat network

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ var ws = archive.createWriteStream()
 ws.write('Hello World!')
 ws.end()
 
+// Now, allow the Dat network to see this new data, example.txt
+archive.replicate()
+
 // Next time your app loads
 
 var repo = dat.get(localStorage.getItem('My_Repo'), {


### PR DESCRIPTION
Can we add
```
archive.replicate()
```
after the `writeFile()` since this was the only way I could get the data to be seen at `datbase.org`?