### PR TITLE
Added option to support extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ class Dat extends EventEmitter {
       id: this.opts.id,
       live: true,
       encrypt: true,
+      extensions: this.opts.extensions,
     })
 
     stream.on('feed', (discoveryKey) => this._replicateFeed(stream, discoveryKey))


### PR DESCRIPTION
As per [the PR in hyperdiscovery](https://github.com/datproject/hyperdiscovery/pull/32), I added the option to specify extensions to use with the hypercore protocol for use cases such as [dat-peers](https://github.com/RangerMauve/dat-peers)