### PR TITLE
Update: bumps random access web dep to its latest version

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -4,3 +4,9 @@ browsers:
     version: -1..latest
   - name: firefox
     version: -1..latest
+browserify:
+  - transform:
+      name: babelify
+      presets:
+        - @babel/preset-env
+

--- a/package.json
+++ b/package.json
@@ -25,15 +25,18 @@
     "hypercore-protocol": "^6.9.0",
     "hyperdrive": "^9.4.7",
     "random-access-memory": "^2.4.0",
-    "random-access-web": "^2.0.1",
+    "random-access-web": "^2.0.2",
     "run-parallel": "^1.1.9"
   },
   "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "babelify": "^10.0.0",
     "browserify": "^14.1.0",
     "concat-stream": "^2.0.0",
     "pump": "^3.0.0",
     "tape": "^4.6.3",
-    "uglifyjs": "^2.4.10",
+    "uglify-es": "^3.3.9",
     "zuul": "^3.11.1"
   },
   "keywords": [


### PR DESCRIPTION
This PR closes #28 

It bumps random-access-web to its latest version and also adds some tweaks to the zuul config so it can parse the tests to es5 compat code. [Here](https://github.com/defunctzombie/zuul/issues/292) it is a related open issue on zuul repo.
So, now if one runs `npm run build-tests` and `npm run test-local` it works and we can enable this behavior on travis too :)